### PR TITLE
Исправить загрузку истории чата oto-chat

### DIFF
--- a/src/pages/oto-chat/model/chat-navigation.service.ts
+++ b/src/pages/oto-chat/model/chat-navigation.service.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject } from 'rxjs';
 import { OtoChat } from './oto.chat';
 import { UserStateService } from './user-state.service';
 import { MessageStateService } from './message-state.service';
+import { OtoChatApiService } from '../api/oto-chat/oto-chat-hub.api';
 
 export interface NavigationState {
   pendingChatUser?: { nickName: string; image: string };
@@ -21,7 +22,8 @@ export class ChatNavigationService {
   constructor(
     private router: Router,
     private userStateService: UserStateService,
-    private messageStateService: MessageStateService
+    private messageStateService: MessageStateService,
+    private otoChatApi: OtoChatApiService
   ) {}
 
   getCurrentNavigationState(): NavigationState {
@@ -72,6 +74,9 @@ export class ChatNavigationService {
     this.userStateService.setSelectedChat(chat.nickName, chat.image, chat);
     this.messageStateService.resetEditingStates();
     this.messageStateService.forceMessageComponentReload();
+    
+    // Load chat history when selecting a chat
+    this.otoChatApi.loadChatHistory(chat.nickName, 20, 0).subscribe();
     
     this.updateState({ isNavigating: false });
   }

--- a/src/pages/oto-chat/ui/page/oto-chat-page.html
+++ b/src/pages/oto-chat/ui/page/oto-chat-page.html
@@ -26,6 +26,7 @@
             #messagesComponent
             [chatNickName]="selectedChat.nickName" 
             [currentUserNickName]="(chatState$ | async)?.currentUserNickName || ''"
+            [loadHistory]="otoChatApi.loadChatHistory.bind(otoChatApi)"
             (editMessage)="onEditMessage($event)"
             (deleteMessage)="onDeleteMessage($event)"
             (replyToMessage)="onReplyToMessage($event)"

--- a/src/pages/oto-chat/ui/page/oto-chat-page.ts
+++ b/src/pages/oto-chat/ui/page/oto-chat-page.ts
@@ -78,7 +78,7 @@ export class OtoChatPageComponent extends BaseChatPageComponent implements OnIni
   }
 
   constructor(
-    private otoChatApi: OtoChatApiService,
+    public otoChatApi: OtoChatApiService,
   ) {
     super();
     this.apiService = this.otoChatApi;
@@ -90,6 +90,9 @@ export class OtoChatPageComponent extends BaseChatPageComponent implements OnIni
     this.subscribeToEvents();
     
     this.chatFacade.handlePendingChatUser(this.chatListComponent);
+    
+    // Set up global variables for oto-chat messages widget
+    this.setupGlobalVariables();
   }
 
   override ngOnDestroy(): void {
@@ -175,5 +178,15 @@ export class OtoChatPageComponent extends BaseChatPageComponent implements OnIni
   @HostListener('document:keydown.escape')
   onEscapePressed(): void {
     this.chatFacade.closeCurrentChat();
+  }
+
+  private setupGlobalVariables(): void {
+    // Set up global loadHistory function
+    (window as any).__otoLoadHistory = (nick: string, take: number, skip: number) => {
+      return this.otoChatApi.loadChatHistory(nick, take, skip);
+    };
+
+    // Set up global messages$ observable
+    (window as any).__otoMessages$ = this.otoChatApi.messages$;
   }
 }


### PR DESCRIPTION
Fixes oto-chat history not loading by ensuring the history loading function is passed to the message widget and triggered on chat selection.

The `oto-chat-messages` widget was not receiving the necessary `loadHistory` input, and the `ChatNavigationService` was missing the call to load history when a chat was selected. This PR aligns the oto-chat history loading mechanism with the existing group-chat implementation, ensuring proper data flow and initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-84aa1d72-7a11-4840-a39f-2a3b7806c09c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84aa1d72-7a11-4840-a39f-2a3b7806c09c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

